### PR TITLE
Fix link in footer

### DIFF
--- a/microsite/docs/Glossary.md
+++ b/microsite/docs/Glossary.md
@@ -1,29 +1,29 @@
 ---
-sidebar_position: 4
+sidebar_position: 3
 ---
 
 # Glossary
 
-  * **3GPP** - 3rd Generation Partnership
-  * **5G-NR** - 5G New Radio
-  * **AF** - Application Functions
-  * **AMF** - Access and Mobility Management Function
-  * **AUSF** - Authentication Server Function
-  * **KYC** - Know Your Customer
-  * **NaaS** - Network-as-a-Service
-  * **NEF** - Network Exposure Function
-  * **NF** - Network Functions
-  * **NRF** - Network Repository Function
-  * **NSSF** - Network Slice Selection Function
-  * **ODA** - Open Digital Architecture
-  * **OSS** - Operation Support System
-  * **OTP** - One Time Password
-  * **PCF** - Policy Control Function
-  * **QoD** - Quality on Demand
-  * **QoS** - Quality of Service
-  * **RAN** - Radio Access Network
-  * **SMF** - Session Management Function
-  * **SMSC** - SMS Center
-  * **SMSF** - SMS Function
-  * **UDM** - Unified Data Management
-  * **UPF** - User Plane Function
+- **3GPP** - 3rd Generation Partnership
+- **5G-NR** - 5G New Radio
+- **AF** - Application Functions
+- **AMF** - Access and Mobility Management Function
+- **AUSF** - Authentication Server Function
+- **KYC** - Know Your Customer
+- **NaaS** - Network-as-a-Service
+- **NEF** - Network Exposure Function
+- **NF** - Network Functions
+- **NRF** - Network Repository Function
+- **NSSF** - Network Slice Selection Function
+- **ODA** - Open Digital Architecture
+- **OSS** - Operation Support System
+- **OTP** - One Time Password
+- **PCF** - Policy Control Function
+- **QoD** - Quality on Demand
+- **QoS** - Quality of Service
+- **RAN** - Radio Access Network
+- **SMF** - Session Management Function
+- **SMSC** - SMS Center
+- **SMSF** - SMS Function
+- **UDM** - Unified Data Management
+- **UPF** - User Plane Function

--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -78,6 +78,7 @@ const config: Config = {
         {
           label: "GitHub",
           href: "https://github.com/ATNoG/gsma-open-gw-apis/tree/main/microsite",
+          className: "margin--horiz-auto",
         },
       ],
       copyright: `

--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -18,7 +18,7 @@ const config: Config = {
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: "pi", // Usually your GitHub org/user name.
-  projectName: "docusaurus", // Usually your repo name.
+  projectName: "gsma-open-gw-apis", // Usually your repo name.
 
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
@@ -56,15 +56,16 @@ const config: Config = {
       title: "GSMA Open Gateway APIs",
       items: [
         {
+          type: "docsVersionDropdown",
+          position: "left",
+        },
+        {
           type: "docSidebar",
           sidebarId: "documentationSidebar",
           position: "left",
           label: "Documentation",
         },
-        {
-          type: "docsVersionDropdown",
-          position: "left",
-        },
+        { to: "/documents", label: "Documents", position: "left" },
         {
           href: "https://github.com/ATNoG/gsma-open-gw-apis",
           label: "GitHub",

--- a/microsite/src/css/custom.css
+++ b/microsite/src/css/custom.css
@@ -28,3 +28,8 @@
   --ifm-color-primary-lightest: #ff5f57;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
+
+.margin--horiz-auto {
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/microsite/src/pages/documents.md
+++ b/microsite/src/pages/documents.md
@@ -1,7 +1,3 @@
----
-sidebar_position: 3
----
-
 # Documents
 
 - [Calendar for the project](/documents/calendar.pdf)

--- a/microsite/src/pages/markdown-page.md
+++ b/microsite/src/pages/markdown-page.md
@@ -1,7 +1,0 @@
----
-title: Markdown page example
----
-
-# Markdown page example
-
-You don't need React to write simple standalone pages.


### PR DESCRIPTION
Fixed uncentered GitHub link in the footer on mobile:

![image](https://github.com/user-attachments/assets/293e7ab3-4a46-4af2-89f7-1095cb291fa3)

Moved documents page from documentation into its own page

![image](https://github.com/user-attachments/assets/e16695f8-fcb9-453c-8ff8-f76d1c9cbcf9)

![image](https://github.com/user-attachments/assets/b9e0be6c-57a2-4f19-8f6f-4d197ab58db4)
