### PR TITLE
fix(gateway): Fixed notification being sent regardless of previous state

### DIFF
--- a/gateway/app/drivers/geofencing/nef/nef.py
+++ b/gateway/app/drivers/geofencing/nef/nef.py
@@ -313,7 +313,7 @@ class NefGeofencingSubscriptionInterface(GeofencingSubscriptionInterface):
             await self.redis.set(key, state.value)
             return False
 
-        if last_state == state:
+        if last_state == state.value:
             return False
 
         await self.redis.set(key, state.value)


### PR DESCRIPTION
Notifications were being sent regardless of being of the previous location of the device. 

Example: If a subscription was set for area entered, notifications would be sent whenever the device was inside the area.
The expected behavior is to send a notification one time when going from outside to inside the area.